### PR TITLE
Legacy variable substitution

### DIFF
--- a/roles/mongo/tasks/main.yml
+++ b/roles/mongo/tasks/main.yml
@@ -15,5 +15,5 @@
 
 - name: Install mongo
   sudo: yes
-  apt: pkg=mongodb-10gen=${mongo_version} state=installed
+  apt: pkg=mongodb-10gen={{ mongo_version }} state=installed
   when: installed_mongo_version != mongo_version

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -2,8 +2,8 @@
 
 - name: install common packages needed for node development
   sudo: yes
-  apt: pkg=$item state=installed
-  when_string: $installed_node_version != $node_version
+  apt: pkg={{item}} state=installed
+  when: installed_node_version != node_version
   with_items:
     - g++
     - curl
@@ -13,31 +13,31 @@
     - make
 
 - name: fetch node source code
-  command: wget http://nodejs.org/dist/${node_version}/node-${node_version}.tar.gz
+  command: wget http://nodejs.org/dist/{{node_version}}/node-{{node_version}}.tar.gz creates=node-{{node_version}}.tar.gz
   when: installed_node_version != node_version
 
 - name: expand node source code
-  command: tar xzf node-${node_version}.tar.gz
+  command: tar xzf node-{{node_version}}.tar.gz
   when: installed_node_version != node_version
 
 - name: configure node
-  command: chdir=/home/deploy/node-${node_version} ./configure
+  command: chdir=/home/{{ansible_user_id}}/node-{{node_version}} ./configure
   when: installed_node_version != node_version
 
 - name: make node
-  command: chdir=/home/deploy/node-${node_version} make -j 3
+  command: chdir=/home/{{ansible_user_id}}/node-{{node_version}} make -j 3
   when: installed_node_version != node_version
 
 - name: install node
-  command: chdir=/home/deploy/node-${node_version} make install
+  command: chdir=/home/{{ansible_user_id}}/node-{{node_version}} make install
   when: installed_node_version != node_version
 
 - name: clean node build directory
-  file: path=node-${node_version} state=absent
+  file: path=node-{{node_version}} state=absent
   when: installed_node_version != node_version
 
 - name: clean node source file
-  file: path=node-${node_version}.tar.gz state=absent
+  file: path=node-{{node_version}}.tar.gz state=absent
   when: installed_node_version != node_version
   
 - name: npm install forever -g

--- a/roles/s3cmd/tasks/main.yml
+++ b/roles/s3cmd/tasks/main.yml
@@ -5,4 +5,4 @@
   apt: pkg=s3cmd state=installed
 
 - name: install s3cmd config
-  template: src=.s3cfg dest=/home/deploy/.s3cfg
+  template: src=.s3cfg dest=/home/{{ ansible_user_id }}/.s3cfg


### PR DESCRIPTION
[DEPRECATION WARNING]: Legacy variable substitution, such as using ${foo} or
$foo instead of {{ foo }} is currently valid but will be phased out and has
been out of favor since version 1.2. This is the last of legacy features on our
deprecation list. You may continue to use this if you have specific needs for
now. This feature will be removed in version 1.6. Deprecation warnings can be
disabled by setting deprecation_warnings=False in ansible.cfg.
